### PR TITLE
BUGFIX: Reset cache backend iterator state on update

### DIFF
--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -131,6 +131,8 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
         } else {
             throw new Exception('Could not set value.', 1232986877);
         }
+
+        $this->cacheEntriesIterator = null;
     }
 
     /**
@@ -173,6 +175,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     public function remove(string $entryIdentifier): bool
     {
         $this->removeIdentifierFromAllTags($entryIdentifier);
+        $this->cacheEntriesIterator = null;
         return apcu_delete($this->identifierPrefix . 'entry_' . $entryIdentifier);
     }
 
@@ -236,6 +239,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
         foreach ($identifiers as $identifier) {
             $this->remove($identifier);
         }
+        $this->cacheEntriesIterator = null;
         return count($identifiers);
     }
 

--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -188,6 +188,8 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
 
             throw $exception;
         }
+
+        $this->cacheEntriesIterator = null;
     }
 
     /**
@@ -251,6 +253,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             $rowsWereDeleted = $this->removeWithoutTransaction($entryIdentifier);
             $this->databaseHandle->commit();
 
+            $this->cacheEntriesIterator = null;
             return $rowsWereDeleted;
         } catch (\Exception $exception) {
             $this->databaseHandle->rollBack();
@@ -306,6 +309,8 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
 
             throw $exception;
         }
+
+        $this->cacheEntriesIterator = null;
     }
 
     /**
@@ -337,6 +342,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             throw $exception;
         }
 
+        $this->cacheEntriesIterator = null;
         return $flushed;
     }
 

--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -159,6 +159,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
             if ($this->cacheEntryFileExtension === '.php') {
                 OpcodeCacheHelper::clearAllActive($cacheEntryPathAndFilename);
             }
+            $this->cacheFilesIterator = null;
             return;
         }
 
@@ -257,6 +258,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
 
                 if ($result === true) {
                     clearstatcache(true, $cacheEntryPathAndFilename);
+                    $this->cacheFilesIterator = null;
                     return $result;
                 }
             } catch (\Exception $e) {
@@ -277,6 +279,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
     public function flush()
     {
         Files::emptyDirectoryRecursively($this->cacheDirectory);
+        $this->cacheFilesIterator = null;
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
@@ -273,6 +273,128 @@ class ApcuBackendTest extends BaseTestCase
     }
 
     /**
+     * @test
+     */
+    public function iterationOverEmptyCacheYieldsNoData()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationOverNotEmptyCacheYieldsData()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData');
+        $cache->set('second', 'secondData');
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataIsSet()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData');
+        $cache->set('second', 'secondData');
+
+        \iterator_to_array(
+            $cache->getIterator()
+        );
+
+        $cache->set('third', 'thirdData');
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData', 'third' => 'thirdData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushed()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData');
+        \iterator_to_array(
+            $cache->getIterator()
+        );
+
+        $backend->flush();
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushedByTag()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData', ['tag']);
+        \iterator_to_array(
+            $cache->getIterator()
+        );
+
+        $backend->flushByTag('tag');
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataGetsRemoved()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData');
+        \iterator_to_array(
+            $cache->getIterator()
+        );
+
+        $backend->remove('first');
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEmpty($data);
+    }
+
+    /**
      * Sets up the APCu backend used for testing
      *
      * @return ApcuBackend
@@ -283,6 +405,7 @@ class ApcuBackendTest extends BaseTestCase
         $cache = $this->createMock(FrontendInterface::class);
         $backend = new ApcuBackend($this->getEnvironmentConfiguration(), []);
         $backend->setCache($cache);
+        $backend->flush(); // I'd rather start with a clean directory in the first place, but I can't get the "vfs" thing to work
 
         return $backend;
     }

--- a/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
@@ -217,6 +217,101 @@ class PdoBackendTest extends BaseTestCase
     }
 
     /**
+     * @test
+     */
+    public function iterationOverEmptyCacheYieldsNoData()
+    {
+        $backend = $this->setUpBackend();
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationOverNotEmptyCacheYieldsData()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData');
+        $backend->set('second', 'secondData');
+
+        $data = \iterator_to_array($backend);
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataIsSet()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData');
+        $backend->set('second', 'secondData');
+        \iterator_to_array($backend);
+
+        $backend->set('third', 'thirdData');
+
+        $data = \iterator_to_array($backend);
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData', 'third' => 'thirdData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushed()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData');
+        \iterator_to_array($backend);
+
+        $backend->flush();
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushedByTag()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData', ['tag']);
+        \iterator_to_array($backend);
+
+        $backend->flushByTag('tag');
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataGetsRemoved()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData');
+        \iterator_to_array($backend);
+
+        $backend->remove('first');
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
      * Sets up the APC backend used for testing
      *
      * @return PdoBackend

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -476,4 +476,83 @@ class SimpleFileBackendTest extends BaseTestCase
         }
         $this->assertEquals(100, $i);
     }
+
+    /**
+     * @test
+     */
+    public function iterationOverEmptyCacheYieldsNoData()
+    {
+        $backend = $this->getSimpleFileBackend();
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationOverNotEmptyCacheYieldsData()
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        $backend->set('first', 'firstData');
+        $backend->set('second', 'secondData');
+
+        $data = \iterator_to_array($backend);
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataIsSet()
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        $backend->set('first', 'firstData');
+        $backend->set('second', 'secondData');
+        \iterator_to_array($backend);
+
+        $backend->set('third', 'thirdData');
+
+        $data = \iterator_to_array($backend);
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData', 'third' => 'thirdData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataGetsRemoved()
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        $backend->set('first', 'firstData');
+        \iterator_to_array($backend);
+
+        $backend->remove('first');
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushed()
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        $backend->set('first', 'firstData');
+        \iterator_to_array($backend);
+
+        $backend->flush();
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
 }


### PR DESCRIPTION
Some cache backends hold an internal state when used as an iterator.
This state needs to be reset whenever the source data is updated.